### PR TITLE
fix: get string from nested option

### DIFF
--- a/resources/views/siteboss/forms/fields/radio.blade.php
+++ b/resources/views/siteboss/forms/fields/radio.blade.php
@@ -10,7 +10,7 @@
 
     <div>
         @foreach ($optionList as $option)
-            @php($optionString = $getByLanguage($option))
+            @php($optionString = $getByLanguage($option->option))
             <div class="form-check form-check-inline">
                 <input class="form-check-input"
                     type="radio"


### PR DESCRIPTION
This is where the string data lives now; maybe better fix would be to unnest this?