### PR TITLE
feat: connect custom model to page controller

### DIFF
--- a/src/Http/Controllers/Pages/PageController.php
+++ b/src/Http/Controllers/Pages/PageController.php
@@ -54,6 +54,13 @@ class PageController extends Controller
         return $this->pageId;
     }
 
+    /**
+     * menuItem
+     *
+     * This will fetch the Menu model for the current page.
+     * You can subclass Menu and add a custom model to the
+     * $model property to use a custom model.
+     */
     protected function menuItem(): Menu
     {
         if ($this->menuItem === null) {

--- a/src/Http/Controllers/Pages/PageController.php
+++ b/src/Http/Controllers/Pages/PageController.php
@@ -35,6 +35,7 @@ class PageController extends Controller
             $pageValues = $this->getPageValues();
             $pvObj = new AssetValues($pageValues);
             if ($this->currentPage) {
+                View::share('title', $this->getFullTitle());
                 View::share('p', $pvObj);
                 View::share('c', $this);
                 View::share('g', $globalPageValues);
@@ -65,6 +66,11 @@ class PageController extends Controller
     public function getTitle(): ?string
     {
         return $this->menuItem()->getTitle() ?? '';
+    }
+
+    public function getFullTitle(): string
+    {
+        return $this->getTitle().' - '.config('app.name');
     }
 
     public function slug(): string

--- a/src/Http/Controllers/Pages/PageController.php
+++ b/src/Http/Controllers/Pages/PageController.php
@@ -18,6 +18,8 @@ class PageController extends Controller
 
     protected bool $currentPage = false;
 
+    protected string $model = Menu::class;
+
     public function __construct(
         protected ?int $pageId = null
     ) {
@@ -33,7 +35,6 @@ class PageController extends Controller
             $pageValues = $this->getPageValues();
             $pvObj = new AssetValues($pageValues);
             if ($this->currentPage) {
-                View::share('title', $this->getFullTitle());
                 View::share('p', $pvObj);
                 View::share('c', $this);
                 View::share('g', $globalPageValues);
@@ -55,7 +56,7 @@ class PageController extends Controller
     protected function menuItem(): Menu
     {
         if ($this->menuItem === null) {
-            $this->menuItem = Menu::whereId($this->id())->firstOrFail();
+            $this->menuItem = $this->model::whereId($this->id())->firstOrFail();
         }
 
         return $this->menuItem;
@@ -64,11 +65,6 @@ class PageController extends Controller
     public function getTitle(): ?string
     {
         return $this->menuItem()->getTitle() ?? '';
-    }
-
-    public function getFullTitle(): string
-    {
-        return $this->getTitle().' - '.config('app.name');
     }
 
     public function slug(): string


### PR DESCRIPTION
When using a PageController, you will now be able to define a custom Model to use as the menuItem()

This allows you to add custom relations in the model without sharing it with other pages.