### PR TITLE
fix: image component + empty search string

### DIFF
--- a/src/Models/Indexes/SolrIndex.php
+++ b/src/Models/Indexes/SolrIndex.php
@@ -280,6 +280,9 @@ class SolrIndex extends BaseModel
 
     public function selectItems($query, $lang = 'nl', $filter = null, $start = null, $rows = null, $extraColumns = [], $highlightLength = 50, $sortField = null, $sortDirection = 'desc')
     {
+        if (trim($query) === '') {
+            return null;
+        }
         $curl = $this->solrHandler();
         $url = sprintf(
             '%s/select?q=title_%s:%s%%20content_%s:%s&spellcheck.q=%s&wt=%s&hl=%s&q.op=%s&hl.fl=%s&fl=%s&spellcheck=true&hl.fragsize=%d&hl.maxAnalyzedChars=%d&spellcheck.dictionary=spellcheck_%s',

--- a/src/Services/Assets/Components/ComponentImage.php
+++ b/src/Services/Assets/Components/ComponentImage.php
@@ -1,6 +1,7 @@
 <?php
 
-declare(strict_types=1);
+// TODO: enable strict_types
+// declare(strict_types=1);
 
 namespace NotFound\Framework\Services\Assets\Components;
 
@@ -170,7 +171,7 @@ class ComponentImage extends AbstractComponent
             }
         } else {
             $menu = Menu::find($this->recordId);
-            if ($menu) {
+            if ($menu && $menu->updated_at) {
                 $updatedAt = $menu->updated_at->getTimestamp();
             }
         }

--- a/src/Services/Assets/Components/ComponentImage.php
+++ b/src/Services/Assets/Components/ComponentImage.php
@@ -171,8 +171,7 @@ class ComponentImage extends AbstractComponent
         } else {
             $menu = Menu::find($this->recordId);
             if ($menu) {
-                $date = new DateTime($menu->updated_at ?? '2020-01-01 00:00:00');
-                $updatedAt = $date->getTimestamp();
+                $updatedAt = $menu->updated_at->getTimestamp();
             }
         }
 


### PR DESCRIPTION
1. Image Component may cause problems in strict mode or with databases that don't contain timestamps for updated_at.
2. Empty search queries no longer trigger an error in SOLR.