### PR TITLE
fix: add nullable (#163)

### DIFF
--- a/database/migrations/2023_10_25_171457_add_created_at_to_menu_table.php
+++ b/database/migrations/2023_10_25_171457_add_created_at_to_menu_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('menu', function (Blueprint $table) {
-            $table->timestamp('created_at');
+            $table->timestamp('created_at')->nullable();
         });
     }
 


### PR DESCRIPTION
Migration did not work because the updated_at field was not nullable.