### PR TITLE
fix: autoload policies

### DIFF
--- a/src/Models/Forms/Policies/CategoryPolicy.php
+++ b/src/Models/Forms/Policies/CategoryPolicy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace NotFound\Framework\Policies\Forms;
+namespace NotFound\Framework\Models\Forms\Policies;
 
 use NotFound\Framework\Models\CmsUser;
 use NotFound\Framework\Models\Forms\Category;

--- a/src/Models/Forms/Policies/DataPolicy.php
+++ b/src/Models/Forms/Policies/DataPolicy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace NotFound\Framework\Policies\Forms;
+namespace NotFound\Framework\Models\Forms\Policies;
 
 use NotFound\Framework\Models\CmsUser;
 use NotFound\Framework\Models\Forms\Data;

--- a/src/Models/Forms/Policies/FormPolicy.php
+++ b/src/Models/Forms/Policies/FormPolicy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace NotFound\Framework\Policies\Forms;
+namespace NotFound\Framework\Models\Forms\Policies;
 
 use NotFound\Framework\Models\CmsUser;
 use NotFound\Framework\Models\Forms\Form;

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -12,18 +12,6 @@ use NotFound\Framework\Providers\Auth\OpenIDUserProvider;
 class AuthServiceProvider extends ServiceProvider
 {
     /**
-     * The policy mappings for the application.
-     *
-     * @var array
-     */
-    protected $policies = [
-        'NotFound\Framework\Models\Forms\Data' => 'NotFound\Framework\Policies\Forms\DataPolicy',
-        'NotFound\Framework\Models\Forms\Form' => 'NotFound\Framework\Policies\Forms\FormPolicy',
-        'NotFound\Framework\Models\Forms\Category' => 'NotFound\Framework\Policies\Forms\CategoryPolicy',
-        'NotFound\Framework\Models\Table' => 'NotFound\Framework\Policies\TablePolicy',
-    ];
-
-    /**
      * Register any authentication / authorization services.
      */
     public function boot()


### PR DESCRIPTION
Previously the policies were places in a location that did not support autoloading the policies. 

This will remove the need for policies in the AuthServiceProvider of the containing project.