### PR TITLE
fix: image resize library update

### DIFF
--- a/src/Services/Assets/Components/ComponentImage.php
+++ b/src/Services/Assets/Components/ComponentImage.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Intervention\Image\ImageManager;
+use Intervention\Image\Drivers\Imagick\Driver;
 use NotFound\Framework\Models\Menu;
 use NotFound\Framework\Services\Assets\Enums\AssetType;
 use NotFound\Layout\Elements\AbstractLayout;
@@ -86,7 +87,11 @@ class ComponentImage extends AbstractComponent
             $filename = $this->recordId.'_'.$dimensions->filename.'.jpg';
 
             // create new image instance
-            $image = (new ImageManager(['driver' => 'imagick']))->make(new File(request()->file($fileId)->path()));
+            $image = (new ImageManager(
+                
+                new Driver()
+
+            ))->read(new File(request()->file($fileId)->path()));
 
             if ($dimensions->height === '0') {
                 $height = intval($image->height() / $image->width() * $width);
@@ -101,13 +106,13 @@ class ComponentImage extends AbstractComponent
                     $constraint->upsize();
                 });
             } else {
-                $image->fit($width, $height);
+                $image->cover($width, $height);
             }
 
-            $image->save(
+            $image->toJpeg()->save(
                 Storage::path('public').$this->relativePathToPublicDisk().$filename
             );
-            $image->save(
+            $image->toWebp()->save(
                 Storage::path('public').$this->relativePathToPublicDisk().$filename.'.webp'
             );
         }

--- a/src/Services/Assets/Components/ComponentImage.php
+++ b/src/Services/Assets/Components/ComponentImage.php
@@ -10,8 +10,8 @@ use Illuminate\Http\File;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Imagick\Driver;
+use Intervention\Image\ImageManager;
 use NotFound\Framework\Models\Menu;
 use NotFound\Framework\Services\Assets\Enums\AssetType;
 use NotFound\Layout\Elements\AbstractLayout;
@@ -88,7 +88,7 @@ class ComponentImage extends AbstractComponent
 
             // create new image instance
             $image = (new ImageManager(
-                
+
                 new Driver()
 
             ))->read(new File(request()->file($fileId)->path()));

--- a/src/Services/Assets/Components/ComponentImage.php
+++ b/src/Services/Assets/Components/ComponentImage.php
@@ -88,9 +88,7 @@ class ComponentImage extends AbstractComponent
 
             // create new image instance
             $image = (new ImageManager(
-
                 new Driver()
-
             ))->read(new File(request()->file($fileId)->path()));
 
             if ($dimensions->height === '0') {
@@ -101,12 +99,9 @@ class ComponentImage extends AbstractComponent
             }
 
             if (isset($dimensions->cropType) && $dimensions->cropType === 'fitWithin') {
-                $image->resize($width, $height, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                });
+                $image->scaleDown($width, $height);
             } else {
-                $image->cover($width, $height);
+                $image->coverDown($width, $height);
             }
 
             $image->toJpeg()->save(

--- a/src/Services/Assets/Components/ComponentText.php
+++ b/src/Services/Assets/Components/ComponentText.php
@@ -4,8 +4,8 @@ namespace NotFound\Framework\Services\Assets\Components;
 
 use Illuminate\Http\File;
 use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Imagick\Driver;
+use Intervention\Image\ImageManager;
 use NotFound\Framework\Models\EditorSetting;
 use NotFound\Framework\Models\FileUpload;
 use NotFound\Framework\Services\Assets\Enums\AssetType;
@@ -97,7 +97,7 @@ class ComponentText extends AbstractComponent
 
         // create new image instance
         $image = (new ImageManager(
-                
+
             new Driver()
 
         ))->read(new File(request()->file('file')));

--- a/src/Services/Assets/Components/ComponentText.php
+++ b/src/Services/Assets/Components/ComponentText.php
@@ -97,9 +97,7 @@ class ComponentText extends AbstractComponent
 
         // create new image instance
         $image = (new ImageManager(
-
             new Driver()
-
         ))->read(new File(request()->file('file')));
         $image->scaleDown($width, null);
 

--- a/src/Services/Assets/Components/ComponentText.php
+++ b/src/Services/Assets/Components/ComponentText.php
@@ -5,6 +5,7 @@ namespace NotFound\Framework\Services\Assets\Components;
 use Illuminate\Http\File;
 use Illuminate\Support\Facades\Storage;
 use Intervention\Image\ImageManager;
+use Intervention\Image\Drivers\Imagick\Driver;
 use NotFound\Framework\Models\EditorSetting;
 use NotFound\Framework\Models\FileUpload;
 use NotFound\Framework\Services\Assets\Enums\AssetType;
@@ -95,12 +96,14 @@ class ComponentText extends AbstractComponent
         $width = 1200;
 
         // create new image instance
-        $image = (new ImageManager(['driver' => 'imagick']))->make(new File(request()->file('file')));
-        $image->resize($width, null, function ($constraint) {
-            $constraint->aspectRatio();
-        });
+        $image = (new ImageManager(
+                
+            new Driver()
 
-        $image->save(
+        ))->read(new File(request()->file('file')));
+        $image->scaleDown($width, null);
+
+        $image->toJpeg()->save(
             Storage::path('public').$folder.$filename
         );
 


### PR DESCRIPTION
Intervention Image has been updated to 3.0. This requires a new syntax.