### PR TITLE
fix: CMS users cannot be created as sub is not default null

### DIFF
--- a/database/migrations/2021_10_27_182234_create_cms_user_table.php
+++ b/database/migrations/2021_10_27_182234_create_cms_user_table.php
@@ -23,9 +23,8 @@ class CreateCmsUserTable extends Migration
             $table->json('properties')->nullable();
             $table->integer('enabled')->nullable();
             $table->set('status', ['DRAFT', 'PUBLISHED', 'DELETED'])->default('DRAFT');
-            $table->string('sub')->default('')->unique();
-            /* $table->rememberToken(); */
-            /* $table->timestamps(); */
+            $table->string('sub')->nullable()->unique();
+            $table->timestamps();
         });
     }
 

--- a/database/migrations/2021_10_27_182234_create_cms_user_table.php
+++ b/database/migrations/2021_10_27_182234_create_cms_user_table.php
@@ -23,8 +23,9 @@ class CreateCmsUserTable extends Migration
             $table->json('properties')->nullable();
             $table->integer('enabled')->nullable();
             $table->set('status', ['DRAFT', 'PUBLISHED', 'DELETED'])->default('DRAFT');
-            $table->string('sub')->nullable()->unique();
-            $table->timestamps();
+            $table->string('sub')->default('')->unique();
+            /* $table->rememberToken(); */
+            /* $table->timestamps(); */
         });
     }
 

--- a/database/migrations/2024_01_10_122234_update_cms_user_table
+++ b/database/migrations/2024_01_10_122234_update_cms_user_table
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('cms_user', function (Blueprint $table) {
+            $table->string('sub')->nullable()->unique()->change();  
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};


### PR DESCRIPTION
The value for sub most be nullable for creation to work.

Also added timestamps for more information on accounts.