### PR TITLE
fix: Form dropdown value accesses property id that doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
   "devDependencies": {
     "release-it": "^17.0.1"
   },
-  "version": "0.14.0"
+  "version": "0.14.1"
 }

--- a/src/Services/Forms/Fields/TypeDropdown.php
+++ b/src/Services/Forms/Fields/TypeDropdown.php
@@ -17,12 +17,10 @@ class TypeDropdown extends AbstractType
 
             // For legacy support we also check for the id,
             // This will be removed in the future
-            if (isset($option->index)) {
-                if ($option->index != $this->getValue()) {
-                    continue;
-                } elseif ($option->id != $this->getValue()) {
-                    continue;
-                }
+            if (isset($option->index) && $option->index != $this->getValue()) {
+                continue;
+            } elseif (isset($option->id) && $option->id != $this->getValue()) {
+                continue;
             }
             if (isset($option->option->$langurl)) {
                 $returnString[] = $option->option->$langurl;


### PR DESCRIPTION
This causes errors when accessing the submitted value.