### PR TITLE
fix: no email when verified

### DIFF
--- a/src/Http/Controllers/CmsEditor/CmsEditorController.php
+++ b/src/Http/Controllers/CmsEditor/CmsEditorController.php
@@ -15,7 +15,12 @@ class CmsEditorController extends \NotFound\Framework\Http\Controllers\Controlle
         $widgetPage = new LayoutWidgetHelper(pageTitle: 'CMS Editor', widgetTitle: 'CMS Editor');
         $widgetPage->widget->noPadding();
 
-        $table = new LayoutTable(delete: false, edit: true, create: false);
+        $table = new LayoutTable(
+            delete: false,
+            edit: true,
+            create: false,
+            sort: false
+        );
         $table->addHeader(new LayoutTableHeader('Main menu', 'table'));
 
         $row = new LayoutTableRow(1, '/app/editor/table/');

--- a/src/Providers/Auth/OpenIDUserProvider.php
+++ b/src/Providers/Auth/OpenIDUserProvider.php
@@ -93,10 +93,10 @@ class OpenIDUserProvider implements UserProvider
                 }
                 $model->sub = $identifier;
                 $model->save();
-                if( $model->email_verified_at === null)
-                {
+                if ($model->email_verified_at === null) {
                     $model->sendEmailVerificationNotification();
                 }
+
                 return $model;
             }
         }

--- a/src/Providers/Auth/OpenIDUserProvider.php
+++ b/src/Providers/Auth/OpenIDUserProvider.php
@@ -93,9 +93,10 @@ class OpenIDUserProvider implements UserProvider
                 }
                 $model->sub = $identifier;
                 $model->save();
-
-                $model->sendEmailVerificationNotification();
-
+                if( $model->email_verified_at === null)
+                {
+                    $model->sendEmailVerificationNotification();
+                }
                 return $model;
             }
         }


### PR DESCRIPTION
If account already has email_verified_at set in the database, we don't need to e-mail that person.