### PR TITLE
fix: remove extra remote call

### DIFF
--- a/src/Http/Controllers/CmsEditor/CmsEditorTableItemController.php
+++ b/src/Http/Controllers/CmsEditor/CmsEditorTableItemController.php
@@ -44,7 +44,7 @@ class CmsEditorTableItemController extends \NotFound\Framework\Http\Controllers\
         $form->addInput($internalInput);
 
         $internalInput = new LayoutInputCheckbox('enabled', 'Enabled');
-        $internalInput->setValue($tableItem->enabled === 1 ? true : false);
+        $internalInput->setValue($tableItem->enabled === true ? true : false);
         $form->addInput($internalInput);
 
         $type = ucfirst($tableItem->type);

--- a/src/Http/Controllers/InfoController.php
+++ b/src/Http/Controllers/InfoController.php
@@ -46,8 +46,8 @@ class InfoController extends Controller
         $settings->background = (object) [
             'url' => env('APP_LOGIN_IMAGE_URL', '/siteboss/images/back.jpg'),
             'credits' => (object) [
-                'name' => env('APP_LOGIN_IMAGE_SOURCE_NAME', 'Dr. Matthias Ripp'),
-                'url' => env('APP_LOGIN_IMAGE_SOURCE_URL', 'https://www.flickr.com/photos/56218409@N03/14605956625'),
+                'name' => env('APP_LOGIN_IMAGE_SOURCE_NAME', 'zeitfaenger.at'),
+                'url' => env('APP_LOGIN_IMAGE_SOURCE_URL', 'https://flickr.com/photos/kwarz/'),
                 'license' => env('APP_LOGIN_IMAGE_SOURCE_LICENSE', 'CC BY 2.0'),
             ],
         ];

--- a/src/Services/Assets/Components/ComponentText.php
+++ b/src/Services/Assets/Components/ComponentText.php
@@ -59,6 +59,9 @@ class ComponentText extends AbstractComponent
      */
     protected function customProperties(): object
     {
+        // BUG: TODO: editModel should just be a property, 
+        //            not a server property
+        $customProperties = [];
         if (isset($this->properties()->type) && $this->properties()->type == 'richtext') {
             if (isset($this->properties()->editorSettings) && trim($this->properties()->editorSettings) !== '') {
                 $setting = EditorSetting::where('name', $this->properties()->editorSettings)->first();
@@ -67,11 +70,18 @@ class ComponentText extends AbstractComponent
             }
 
             if (isset($setting->settings)) {
-                return (object) ['editorSettings' => json_decode($setting->settings)];
+                $customProperties['editorSettings'] = json_decode($setting->settings);
             }
         }
+        if (
+            $this->assetItem->properties->type == 'richtext' &&
+         isset( $this->assetItem->server_properties->editModal) && 
+         $this->assetItem->server_properties->editModal === true
+         ) {
+            $customProperties['editModal'] = true;
+        }
 
-        return (object) [];
+        return (object) $customProperties;
     }
 
     public function asyncPostRequest()

--- a/src/Services/Auth/RemoteTokenDecoder.php
+++ b/src/Services/Auth/RemoteTokenDecoder.php
@@ -38,11 +38,6 @@ class RemoteTokenDecoder extends AbstractTokenDecoder
 
     public function getDecodedToken(): \stdClass
     {
-        return $this->getRemoteAuthenticatedToken();
-    }
-
-    private function getRemoteAuthenticatedToken(): \stdClass
-    {
         if ($this->decodedToken === null) {
             $userEndpoint = $this->openIdConfiguration['userinfo_endpoint'];
             if (! $userEndpoint) {

--- a/src/Services/Auth/RemoteTokenDecoder.php
+++ b/src/Services/Auth/RemoteTokenDecoder.php
@@ -7,11 +7,11 @@ use NotFound\Framework\Exceptions\OpenID\OpenIDException;
 
 class RemoteTokenDecoder extends AbstractTokenDecoder
 {
-    private \stdClass $decodedToken;
+    private ?object  $decodedToken = null;
 
     protected function decodeToken(): void
     {
-        $this->decodedToken = $this->getDecodedToken();
+        $this->getDecodedToken();
     }
 
     protected function verifyToken(): void
@@ -43,16 +43,19 @@ class RemoteTokenDecoder extends AbstractTokenDecoder
 
     private function getRemoteAuthenticatedToken(): \stdClass
     {
-        $userEndpoint = $this->openIdConfiguration['userinfo_endpoint'];
-        if (! $userEndpoint) {
-            throw OpenIDException::noUserInfoEndpoint();
+        if ($this->decodedToken === null) {
+            $userEndpoint = $this->openIdConfiguration['userinfo_endpoint'];
+            if (! $userEndpoint) {
+                throw OpenIDException::noUserInfoEndpoint();
+            }
+
+            $response = Http::withToken($this->token)->get($userEndpoint);
+            if (! $response->ok()) {
+                throw new \Exception('Token is invalid.');
+            }
+            $this->decodedToken = (object) $response->json();
         }
 
-        $response = Http::withToken($this->token)->get($userEndpoint);
-        if (! $response->ok()) {
-            throw new \Exception('Token is invalid.');
-        }
-
-        return (object) $response->json();
+        return $this->decodedToken;
     }
 }

--- a/src/Services/Editor/Fields/Text.php
+++ b/src/Services/Editor/Fields/Text.php
@@ -34,7 +34,9 @@ class Text extends Properties
             $options[] = (object) ['value' => $table->name, 'label' => $table->name];
         }
         $this->addDropDown('editorSettings', 'Editor settings (for rich text editor)', $options);
-
+        // BUG: TODO: editModel should just be a property, 
+        //            not a server property
+        $this->addCheckbox('editModal', 'Edit texts in popup (required for ContentBlock/Childtable)');
         $this->addTitle('Validation');
 
         $this->addDropDown('regExTemplate', 'Built in validations', [


### PR DESCRIPTION
When authenticated through OIDC with remote verification. The call is made twice. We'll cache the decoded token for the second call.