### PR TITLE
feat: Remove dbal requirement

### DIFF
--- a/src/Http/Controllers/CmsEditor/CmsEditorTableController.php
+++ b/src/Http/Controllers/CmsEditor/CmsEditorTableController.php
@@ -3,7 +3,6 @@
 namespace NotFound\Framework\Http\Controllers\CmsEditor;
 
 use Illuminate\Http\Request as HttpRequest;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use NotFound\Framework\Http\Requests\FormDataRequest;
 use NotFound\Framework\Models\Table;
@@ -323,7 +322,9 @@ class CmsEditorTableController extends \NotFound\Framework\Http\Controllers\Cont
         $fieldClass = new $className(new stdClass());
 
         if (Schema::hasColumn($table, $field->internal)) {
-            return $fieldClass->checkColumnType(DB::getDoctrineColumn($this->setDatabasePrefix($table), $field->internal)->getType());
+            return $fieldClass->checkColumnType(
+                Schema::getColumnType($table, $field->internal)
+            );
         } else {
             return $fieldClass->checkColumnType(null);
         }

--- a/src/Services/Assets/Components/ComponentText.php
+++ b/src/Services/Assets/Components/ComponentText.php
@@ -72,13 +72,6 @@ class ComponentText extends AbstractComponent
             if (isset($setting->settings)) {
                 $customProperties['editorSettings'] = json_decode($setting->settings);
             }
-
-            if (
-                isset($this->assetItem->server_properties->editModal) &&
-                $this->assetItem->server_properties->editModal === true
-                ) {
-                   $customProperties['editModal'] = true;
-               }
         }
 
         return (object) $customProperties;

--- a/src/Services/Assets/Components/ComponentText.php
+++ b/src/Services/Assets/Components/ComponentText.php
@@ -72,13 +72,13 @@ class ComponentText extends AbstractComponent
             if (isset($setting->settings)) {
                 $customProperties['editorSettings'] = json_decode($setting->settings);
             }
-        }
-        if (
-            $this->assetItem->properties->type == 'richtext' &&
-         isset($this->assetItem->server_properties->editModal) &&
-         $this->assetItem->server_properties->editModal === true
-         ) {
-            $customProperties['editModal'] = true;
+
+            if (
+                isset($this->assetItem->server_properties->editModal) &&
+                $this->assetItem->server_properties->editModal === true
+                ) {
+                   $customProperties['editModal'] = true;
+               }
         }
 
         return (object) $customProperties;

--- a/src/Services/Editor/Fields/Button.php
+++ b/src/Services/Editor/Fields/Button.php
@@ -23,7 +23,7 @@ class Button extends Properties
     {
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         return '';
     }

--- a/src/Services/Editor/Fields/Checkbox.php
+++ b/src/Services/Editor/Fields/Checkbox.php
@@ -21,14 +21,14 @@ class Checkbox extends Properties
     {
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';
         }
 
-        if (! in_array($type->getName(), ['tinyint', 'boolean'])) {
-            return 'TYPE ERROR: '.$type->getName().' is not a valid type for a text field';
+        if (! in_array($type, ['tinyint', 'int', 'boolean'])) {
+            return 'TYPE ERROR: '.$type.' is not a valid type for a text field';
         }
 
         return '';

--- a/src/Services/Editor/Fields/ChildTable.php
+++ b/src/Services/Editor/Fields/ChildTable.php
@@ -34,7 +34,7 @@ class ChildTable extends Properties
         ];
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type !== null) {
             return 'COLUMN NOT NEEDED';

--- a/src/Services/Editor/Fields/ContentBlocks.php
+++ b/src/Services/Editor/Fields/ContentBlocks.php
@@ -28,7 +28,7 @@ class ContentBlocks extends Properties
 
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type !== null) {
             return 'COLUMN NOT NEEDED';

--- a/src/Services/Editor/Fields/DatePicker.php
+++ b/src/Services/Editor/Fields/DatePicker.php
@@ -33,17 +33,17 @@ class DatePicker extends Properties
         ];
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';
         }
-        if ($type->getName() === 'int') {
-            return 'TYPE WARNING: '.$type->getName().' should be converted to datetime';
+        if ($type === 'int') {
+            return 'TYPE WARNING: '.$type.' should be converted to datetime';
         }
 
-        if ($type->getName() !== 'datetime') {
-            return 'TYPE ERROR: '.$type->getName().' is not a valid type for a date field';
+        if ($type !== 'datetime') {
+            return 'TYPE ERROR: '.$type.' is not a valid type for a date field';
         }
 
         return '';

--- a/src/Services/Editor/Fields/DateTimePicker.php
+++ b/src/Services/Editor/Fields/DateTimePicker.php
@@ -22,13 +22,13 @@ class DateTimePicker extends Properties
     {
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';
         }
-        if (! in_array($type->getName(), ['datetime'])) {
-            return 'TYPE ERROR: '.$type->getName().' is not a valid type for a date field';
+        if (! in_array($type, ['datetime'])) {
+            return 'TYPE ERROR: '.$type.' is not a valid type for a date field';
         }
 
         return '';

--- a/src/Services/Editor/Fields/Description.php
+++ b/src/Services/Editor/Fields/Description.php
@@ -20,7 +20,7 @@ class Description extends Properties
     {
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
 
         return '';

--- a/src/Services/Editor/Fields/DropDown.php
+++ b/src/Services/Editor/Fields/DropDown.php
@@ -2,7 +2,6 @@
 
 namespace NotFound\Framework\Services\Editor\Fields;
 
-use Doctrine\DBAL\Types\Type;
 use NotFound\Framework\Services\Editor\Properties;
 use NotFound\Framework\Services\Editor\Repeatable;
 use stdClass;

--- a/src/Services/Editor/Fields/DropDown.php
+++ b/src/Services/Editor/Fields/DropDown.php
@@ -30,7 +30,7 @@ class DropDown extends Properties
     {
     }
 
-    public function checkColumnType(?Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';

--- a/src/Services/Editor/Fields/File.php
+++ b/src/Services/Editor/Fields/File.php
@@ -22,14 +22,14 @@ class File extends Properties
     {
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';
         }
 
-        if (! in_array($type->getName(), ['string'])) {
-            return 'TYPE ERROR: '.$type->getName().' is not a valid type for a text field';
+        if (! in_array($type, ['varchar'])) {
+            return 'TYPE ERROR: '.$type.' is not a valid type for a text field';
         }
 
         return '';

--- a/src/Services/Editor/Fields/Filter.php
+++ b/src/Services/Editor/Fields/Filter.php
@@ -19,7 +19,7 @@ class Filter extends Properties
     {
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         return '';
     }

--- a/src/Services/Editor/Fields/Header.php
+++ b/src/Services/Editor/Fields/Header.php
@@ -20,7 +20,7 @@ class Header extends Properties
     {
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         return '';
     }

--- a/src/Services/Editor/Fields/Image.php
+++ b/src/Services/Editor/Fields/Image.php
@@ -2,7 +2,6 @@
 
 namespace NotFound\Framework\Services\Editor\Fields;
 
-use Doctrine\DBAL\Types\Type;
 use NotFound\Framework\Services\Editor\Properties;
 use NotFound\Framework\Services\Editor\Repeatable;
 use stdClass;

--- a/src/Services/Editor/Fields/Image.php
+++ b/src/Services/Editor/Fields/Image.php
@@ -36,7 +36,7 @@ class Image extends Properties
         $this->addCheckbox('createPNG', 'Create PNG');
     }
 
-    public function checkColumnType(?Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';

--- a/src/Services/Editor/Fields/Link.php
+++ b/src/Services/Editor/Fields/Link.php
@@ -20,7 +20,7 @@ class Link extends Properties
     {
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';

--- a/src/Services/Editor/Fields/ModelSelect.php
+++ b/src/Services/Editor/Fields/ModelSelect.php
@@ -23,13 +23,13 @@ class ModelSelect extends Properties
         $this->addText('methodName', 'Method', true);
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';
         }
-        if (! in_array($type->getName(), ['string', 'integer'])) {
-            return 'TYPE ERROR: '.$type->getName().' is not a valid type for a table select field';
+        if (! in_array($type, ['varchar', 'int'])) {
+            return 'TYPE ERROR: '.$type.' is not a valid type for a table select field';
         }
 
         return '';

--- a/src/Services/Editor/Fields/Number.php
+++ b/src/Services/Editor/Fields/Number.php
@@ -23,7 +23,7 @@ class Number extends Properties
     {
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';

--- a/src/Services/Editor/Fields/Slug.php
+++ b/src/Services/Editor/Fields/Slug.php
@@ -23,13 +23,13 @@ class Slug extends Properties
         $this->addText('source', 'Source field internal name', false);
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';
         }
-        if (! in_array($type->getName(), ['string'])) {
-            return 'TYPE ERROR: '.$type->getName().' is not a valid type for a slug field';
+        if (! in_array($type, ['varchar'])) {
+            return 'TYPE ERROR: '.$type.' is not a valid type for a slug field';
         }
 
         return '';

--- a/src/Services/Editor/Fields/TableSelect.php
+++ b/src/Services/Editor/Fields/TableSelect.php
@@ -40,13 +40,13 @@ class TableSelect extends Properties
         ];
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';
         }
-        if (! in_array($type->getName(), ['string', 'integer'])) {
-            return 'TYPE ERROR: '.$type->getName().' is not a valid type for a table select field';
+        if (! in_array($type, ['int', 'tinyint', 'varchar'])) {
+            return 'TYPE ERROR: '.$type.' is not a valid type for a table select field';
         }
 
         return '';

--- a/src/Services/Editor/Fields/Tags.php
+++ b/src/Services/Editor/Fields/Tags.php
@@ -42,7 +42,7 @@ class Tags extends Properties
         ];
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type !== null) {
             return 'COLUMN NOT NEEDED';

--- a/src/Services/Editor/Fields/Text.php
+++ b/src/Services/Editor/Fields/Text.php
@@ -54,13 +54,13 @@ class Text extends Properties
         return ['texttype' => 'type'];
     }
 
-    public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string
+    public function checkColumnType(?string $type): string
     {
         if ($type === null) {
             return 'COLUMN MISSING';
         }
-        if (! in_array($type->getName(), ['string', 'text'])) {
-            return 'TYPE ERROR: '.$type->getName().' is not a valid type for a text field';
+        if (! in_array($type, ['varchar', 'text'])) {
+            return 'TYPE ERROR: '.$type.' is not a valid type for a text field';
         }
 
         return '';

--- a/src/Services/Editor/Fields/Text.php
+++ b/src/Services/Editor/Fields/Text.php
@@ -24,6 +24,7 @@ class Text extends Properties
             (object) ['value' => 'richtext', 'label' => 'Rich Text'],
         ]);
         $this->addNumber('maxlength', 'Maximum length');
+        $this->addCheckbox('editModal', 'Edit texts in popup (required for ContentBlock/Childtable)');
     }
 
     public function serverProperties(): void
@@ -36,7 +37,6 @@ class Text extends Properties
         $this->addDropDown('editorSettings', 'Editor settings (for rich text editor)', $options);
         // BUG: TODO: editModal should just be a property,
         //            not a server property
-        $this->addCheckbox('editModal', 'Edit texts in popup (required for ContentBlock/Childtable)');
         $this->addTitle('Validation');
 
         $this->addDropDown('regExTemplate', 'Built in validations', [

--- a/src/Services/Editor/Properties.php
+++ b/src/Services/Editor/Properties.php
@@ -39,7 +39,7 @@ abstract class Properties
 
     abstract public function description(): string;
 
-    abstract public function checkColumnType(?\Doctrine\DBAL\Types\Type $type): string;
+    abstract public function checkColumnType(?string $type): string;
 
     protected function addText($property_name, $display_name, $required = false, $default = null)
     {

--- a/src/Services/Editor/Repeatable.php
+++ b/src/Services/Editor/Repeatable.php
@@ -2,8 +2,6 @@
 
 namespace NotFound\Framework\Services\Editor;
 
-use Doctrine\DBAL\Types\Type;
-
 class Repeatable extends Properties
 {
     public function description(): string

--- a/src/Services/Editor/Repeatable.php
+++ b/src/Services/Editor/Repeatable.php
@@ -19,7 +19,7 @@ class Repeatable extends Properties
     {
     }
 
-    public function checkColumnType(?Type $type): string
+    public function checkColumnType(?string $type): string
     {
         trigger_error('This should never be called', E_USER_ERROR);
 


### PR DESCRIPTION
DBAL is required, but not really needed, plus some calls will be removed in Laravel 11.