### PR TITLE
feat: archive message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
   "require": {
     "spatie/laravel-package-tools": "^1.14.0",
     "spatie/laravel-honeypot": "^4.3.2",
-    "notfoundnl/siteboss-layout": "^1.7.0",
-    "notfoundnl/siteboss-static": "^1.15.0",
+    "notfoundnl/siteboss-layout": "^1.8.0",
+    "notfoundnl/siteboss-static": "^1.15.0|dev-main",
     "mcamara/laravel-localization": "^2.0",
     "enshrined/svg-sanitize": "^0.22.0",
     "xenolope/quahog": "^3.0",

--- a/lang/en/ui.php
+++ b/lang/en/ui.php
@@ -26,4 +26,5 @@ return [
     ],
     'email' => 'E-mail',
     'enabled' => 'Enabled',
+    'archive_message' => 'This is an archived item. You may need to restore it first before it is visible on the website.',
 ];

--- a/lang/nl/ui.php
+++ b/lang/nl/ui.php
@@ -26,4 +26,5 @@ return [
     ],
     'email' => 'E-mail',
     'enabled' => 'Geactiveerd',
+    'archive_message' => 'Dit is een gearchiveerd item. Mogelijk moet je dit eerst herstellen voordat het zichtbaar is op de website.',
 ];

--- a/src/Http/Controllers/Assets/TableEditorController.php
+++ b/src/Http/Controllers/Assets/TableEditorController.php
@@ -16,6 +16,7 @@ use NotFound\Layout\Elements\LayoutBar;
 use NotFound\Layout\Elements\LayoutBarButton;
 use NotFound\Layout\Elements\LayoutButton;
 use NotFound\Layout\Elements\LayoutForm;
+use NotFound\Layout\Elements\LayoutMessage;
 use NotFound\Layout\Elements\LayoutPage;
 use NotFound\Layout\Elements\LayoutTitle;
 use NotFound\Layout\Elements\LayoutWidget;
@@ -73,6 +74,12 @@ class TableEditorController extends AssetEditorController
         $form->addButton($saveButton);
 
         $widget = new LayoutWidget($upsertingText);
+
+        if ($table->allow_archive && $tableService->isArchived()) {
+            $message = new LayoutMessage(__('siteboss::ui.archive_message'), 'warning')->setIntroText('ARCHIEF');
+            $widget->addMessage($message);
+        }
+
         if (auth('openid')->user()->hasRole('admin') && request()->query('editor') !== '1') {
             $bar = new LayoutBar;
             $bar->removePadding();

--- a/src/Http/Controllers/Assets/TableOverviewController.php
+++ b/src/Http/Controllers/Assets/TableOverviewController.php
@@ -31,12 +31,12 @@ class TableOverviewController extends AssetEditorController
      * @param  string  $customer  This is an value of tg_cms_table->url column.
      * @return array ['headers' => [{'name' => 'name3','properties' => 'sourcename']], 'rows' => [
      */
-    public function index(Request $request, Table $table, bool $archived = false)
+    public function index(Request $request, Table $table, bool $archiveView = false)
     {
         $tableService = new TableService($table, Lang::default());
         $components = $tableService->getFieldComponentsOverview();
 
-        $tableQueryService = new TableQueryService($table, $components, $archived);
+        $tableQueryService = new TableQueryService($table, $components, $archiveView);
         $siteTableRowsPaginator = $tableQueryService->getSiteTableRows();
 
         $layoutTable = new LayoutTable(
@@ -45,12 +45,12 @@ class TableOverviewController extends AssetEditorController
             archive: $table->allow_archive,
             sort: ($request->sort ? false : $table->allow_sort),
             duplicate: $table->allow_duplicate,
-            archiveView: $archived
+            archiveView: $archiveView
         );
         if ($table->allow_archive) {
             $tabs = new LayoutTabs;
-            $tabs->addTab(new LayoutTab('Actief', '/table/'.$table->url.'', ! $archived));
-            $tabs->addTab(new LayoutTab('Gearchiveerd', '/table/'.$table->url.'/archive', $archived));
+            $tabs->addTab(new LayoutTab('Actief', '/table/'.$table->url.'', ! $archiveView));
+            $tabs->addTab(new LayoutTab('Gearchiveerd', '/table/'.$table->url.'/archive', $archiveView));
         }
 
         $layoutTable->setTotalItems($siteTableRowsPaginator->total());
@@ -87,7 +87,7 @@ class TableOverviewController extends AssetEditorController
         $page = new LayoutPage($table->name);
         $page->addTitle(new LayoutTitle($table->name));
 
-        $page->addBreadCrumb($editor->getBreadCrumbs());
+        $page->addBreadCrumb($editor->getBreadCrumbs($archiveView));
 
         $pager = new LayoutPager(totalItems: $siteTableRowsPaginator->total(), itemsPerPage: request()->query('pitems') ?? $table->properties->itemsPerPage ?? 25);
 

--- a/src/Models/Editor/AbstractEditor.php
+++ b/src/Models/Editor/AbstractEditor.php
@@ -15,7 +15,7 @@ abstract class AbstractEditor
 
     abstract public function getBottomBar(LayoutPager $pager): LayoutBar;
 
-    abstract public function getBreadCrumbs(): LayoutBreadcrumb;
+    abstract public function getBreadCrumbs(bool $archiveView = false): LayoutBreadcrumb;
 
     abstract public function getBreadCrumbsEdit(): LayoutBreadcrumb;
 

--- a/src/Models/Editor/DefaultEditor.php
+++ b/src/Models/Editor/DefaultEditor.php
@@ -52,12 +52,19 @@ class DefaultEditor extends AbstractEditor
         return $bar->addBarButton($addNew);
     }
 
-    public function getBreadCrumbs(): LayoutBreadcrumb
+    public function getBreadCrumbs(bool $archiveView = false): LayoutBreadcrumb
     {
         $table = $this->ts->getAssetModel();
         $breadcrumb = new LayoutBreadcrumb;
         $breadcrumb->addHome();
-        $breadcrumb->addItem($table->name);
+
+        if ($archiveView) {
+            $breadcrumb->addItem($table->name, '/table/'.$table->url.'/');
+            $breadcrumb->addItem('Archief');
+
+        } else {
+            $breadcrumb->addItem($table->name);
+        }
 
         return $breadcrumb;
     }

--- a/src/Services/Assets/TableService.php
+++ b/src/Services/Assets/TableService.php
@@ -15,6 +15,8 @@ class TableService extends AbstractAssetService
 {
     private Collection $fieldComponents;
 
+    private ?object $siteTableRow = null;
+
     public function __construct(
         private Table $table,
         protected Lang $lang,
@@ -45,6 +47,14 @@ class TableService extends AbstractAssetService
     public function addCustomComponent(string $internal, AbstractComponent $component): void
     {
         $this->fieldComponents->put($internal, $component);
+    }
+
+    /**
+     * Whether the current record is archived. Always false for new records.
+     */
+    public function isArchived(): bool
+    {
+        return ($this->siteTableRow->archived_at ?? null) !== null;
     }
 
     public function getType(): AssetType
@@ -170,6 +180,7 @@ class TableService extends AbstractAssetService
     private function setCurrentValues(): void
     {
         $siteTableRow = $this->assetModel->getSiteTableRowByRecordId($this->recordId);
+        $this->siteTableRow = $siteTableRow;
 
         $localizedSiteRow = null;
         if ($this->table->isLocalized()) {


### PR DESCRIPTION
This pull request introduces improvements to the archive handling and UI messaging for table assets, along with dependency updates and better localization support. The main changes include displaying an archive warning message in the editor, enhanced breadcrumb navigation for archive views, and support for distinguishing archived records in the backend logic.

**Archive Handling and UI Improvements:**

* Added an archive warning message to the table editor UI, which appears when editing an archived record (`LayoutMessage` with `archive_message` translation).
* Breadcrumb navigation now reflects whether the user is viewing archived items, both in the backend logic (`getBreadCrumbs` now accepts an `archiveView` parameter) and in the UI. [[1]](diffhunk://#diff-21a9a12351e053f5f9833a77228a87c1e44285f9a4c310e383d2e3ff150c9e1eL18-R18) [[2]](diffhunk://#diff-bf6c690a7ce31d5c40d37a8493981d08e65fb5e8c18f0321a4340f8cd0594c71L55-R67) [[3]](diffhunk://#diff-7b04afa451c83aa431c4cfd970da043e9d59ebe5b30ff412f9f65ab88ff3f43fL90-R90) [[4]](diffhunk://#diff-7b04afa451c83aa431c4cfd970da043e9d59ebe5b30ff412f9f65ab88ff3f43fL34-R39) [[5]](diffhunk://#diff-7b04afa451c83aa431c4cfd970da043e9d59ebe5b30ff412f9f65ab88ff3f43fL48-R53)

**Backend Logic Enhancements:**

* Added `isArchived()` method to `TableService` to determine if the current record is archived, and ensured the service tracks the current site table row. [[1]](diffhunk://#diff-e8a39635c8890b82a40ea12a41de1716f6206e49573d42688a9b29bee47a07ccR52-R59) [[2]](diffhunk://#diff-e8a39635c8890b82a40ea12a41de1716f6206e49573d42688a9b29bee47a07ccR183) [[3]](diffhunk://#diff-e8a39635c8890b82a40ea12a41de1716f6206e49573d42688a9b29bee47a07ccR18-R19)

**Localization:**

* Added `archive_message` translations to both English and Dutch language files. [[1]](diffhunk://#diff-d228fa9bfffe438adfd2af394a06c814fe9dc0b15bd74965ce106018a3c11785R29) [[2]](diffhunk://#diff-3a3456e360139586d782d68096e47cb6db2cf272d2236868986401c6abc1ab42R29)

**Dependency Updates:**

* Updated `notfoundnl/siteboss-layout` to `^1.8.0` and allowed `notfoundnl/siteboss-static` to use `dev-main` in `composer.json`.